### PR TITLE
fix(ci): do not use config cache for oss publish

### DIFF
--- a/.github/workflows/loxone-client-release.yml
+++ b/.github/workflows/loxone-client-release.yml
@@ -58,4 +58,4 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASS: ${{ secrets.SIGNING_PASS }}
         run: |
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew --no-configuration-cache publishToSonatype closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
sonatype plugin does not work with config cache