### PR TITLE
fix(build): exclude acceptanceTest from Kover and fix AT class filter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -196,10 +196,15 @@ tasks.configureEach {
 }
 
 kover {
+    currentProject {
+        instrumentation {
+            disabledForTestTasks.add("jvmAcceptanceTest")
+        }
+    }
     reports {
         filters {
             excludes {
-                classes("cz.smarteon.loxone.*AT*")
+                classes("cz.smarteon.loxkt.*AT*")
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fixes the `kover` class filter package name: `cz.smarteon.loxone.*AT*` → `cz.smarteon.loxkt.*AT*` (the filter never matched because the actual package is `loxkt`, not `loxone`)
- Adds `disabledForTestTasks.add("jvmAcceptanceTest")` so Kover stops treating the `acceptanceTest` compilation's sources and outputs as production code to measure

## Root cause

Kover's default logic auto-excludes only the compilation named exactly `"test"`. The custom `acceptanceTest` compilation has a different name, so Kover included `src/jvmAcceptanceTest/kotlin` and `build/classes/kotlin/jvm/acceptanceTest` in the JVM variant artifact as production code. `LoxoneClientAT` and its inner classes then appeared in the report with 0% coverage, inflating the missed counters.

The existing `classes("cz.smarteon.loxone.*AT*")` filter was intended to exclude these, but used the wrong package (`loxone` instead of `loxkt`) and never matched anything.

> Note: `jvmTest` coverage was always working correctly — `build/kover/bin-reports/jvmTest.ic` was present and its data reached the report. The misleading numbers were caused entirely by the AT class contamination.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)