### PR TITLE
feat(auth): implement token refresh via refreshjwt

### DIFF
--- a/src/commonMain/kotlin/LoxoneCommands.kt
+++ b/src/commonMain/kotlin/LoxoneCommands.kt
@@ -72,6 +72,14 @@ object LoxoneCommands {
         )
 
         /**
+         * Command to refresh token. Uses the modern `refreshjwt` endpoint (protocol ≥ 10.2).
+         * The [tokenHash] must be HMAC of the current token string using a fresh `getkey2` result.
+         */
+        @JvmStatic
+        fun refresh(tokenHash: String, user: String) =
+            sysCommand<Token>("refreshjwt", tokenHash, user, authenticated = false)
+
+        /**
          * Command to kill token.
          * @param tokenHash The token hash to kill.
          * @param user The user to kill the token for.

--- a/src/commonMain/kotlin/LoxoneTokenAuthenticator.kt
+++ b/src/commonMain/kotlin/LoxoneTokenAuthenticator.kt
@@ -66,7 +66,18 @@ class LoxoneTokenAuthenticator @JvmOverloads constructor(
                 }
 
                 state.needsRefresh -> {
-                    TODO("refresh and merge token")
+                    logger.debug { "Token needs refresh, sending refreshjwt" }
+                    val currentToken = checkNotNull(token) { "Token must be present to refresh" }
+                    val refreshed = client.callForMsg(
+                        Tokens.refresh(LoxoneCrypto.loxoneHmac(currentToken, hashing, "refreshjwt"), user)
+                    )
+                    token = currentToken.merge(refreshed)
+                    if (client is WebsocketLoxoneClient) {
+                        logger.debug { "Authenticating websocket with refreshed token" }
+                        val authResponse = client.callForMsg(Tokens.auth(tokenHash(client, "authenticate"), user))
+                        token = checkNotNull(token).merge(authResponse)
+                        authWebsockets.add(client)
+                    }
                 }
 
                 else -> {

--- a/src/commonMain/kotlin/message/Token.kt
+++ b/src/commonMain/kotlin/message/Token.kt
@@ -8,10 +8,10 @@ import kotlinx.serialization.Serializable
 /**
  * Represents Loxone authentication token.
  *
- * @property[token] The actual token value. May be null in case of response to refresh token or `authwithtoken`
- * @property[key] The token key value. May be null in case of response to refresh token or authwithtoken.
+ * @property[token] The actual token value. May be null in case of response to `authwithtoken`.
+ * @property[key] The token key value. May be null in case of response to `refreshjwt` or `authwithtoken`.
  * @property[validUntil] Seconds since loxone epoch (1.1.2009) to which the token is valid.
- * @property[rights]
+ * @property[rights] Permission bitmap. Absent in `refreshjwt` responses; use [merge] to propagate from `getjwt`.
  * @property[unsecurePassword]
  */
 @Serializable
@@ -19,7 +19,7 @@ data class Token(
     val token: String? = null,
     @Serializable(HexSerializer::class) val key: ByteArray? = null,
     val validUntil: Long,
-    @SerialName("tokenRights") val rights: Int,
+    @SerialName("tokenRights") val rights: Int? = null,
     @SerialName("unsecurePass") val unsecurePassword: Boolean
 ) : LoxoneMsgVal {
 
@@ -47,7 +47,7 @@ data class Token(
                 token = other.token ?: token,
                 key = other.key ?: key,
                 validUntil = other.validUntil,
-                rights = other.rights,
+                rights = other.rights ?: rights,
                 unsecurePassword = other.unsecurePassword
             )
         }
@@ -71,7 +71,7 @@ data class Token(
         var result = token?.hashCode() ?: 0
         result = 31 * result + (key?.contentHashCode() ?: 0)
         result = 31 * result + validUntil.hashCode()
-        result = 31 * result + rights
+        result = 31 * result + (rights ?: 0)
         result = 31 * result + unsecurePassword.hashCode()
         result = 31 * result + filled.hashCode()
         return result

--- a/src/commonTest/kotlin/LoxoneCommandsTest.kt
+++ b/src/commonTest/kotlin/LoxoneCommandsTest.kt
@@ -43,4 +43,13 @@ class LoxoneCommandsTest : ShouldSpec({
             it.expectedCode shouldBe "200"
         }
     }
+
+    should("create refresh token command") {
+        LoxoneCommands.Tokens.refresh("hash", "user").asClue {
+            it.pathSegments shouldBe listOf("jdev", "sys", "refreshjwt", "hash", "user")
+            it.valueType shouldBe Token::class
+            it.authenticated shouldBe false
+            it.expectedCode shouldBe "200"
+        }
+    }
 })

--- a/src/commonTest/kotlin/LoxoneTokenAuthenticatorTest.kt
+++ b/src/commonTest/kotlin/LoxoneTokenAuthenticatorTest.kt
@@ -4,6 +4,7 @@ import cz.smarteon.loxkt.LoxoneEndpoint.Companion.local
 import cz.smarteon.loxkt.message.Hashing.Companion.commandForUser
 import cz.smarteon.loxkt.message.LoxoneMsg
 import cz.smarteon.loxkt.message.TestingLoxValues.HASHING
+import cz.smarteon.loxkt.message.TestingLoxValues.token
 import cz.smarteon.loxkt.message.TestingLoxValues.tokenAuthResponse
 import cz.smarteon.loxkt.message.TestingLoxValues.tokenRefreshResponse
 import cz.smarteon.loxkt.message.Token
@@ -16,23 +17,16 @@ import io.kotest.matchers.shouldBe
 class LoxoneTokenAuthenticatorTest : ShouldSpec({
 
     context("with valid token") {
-        val profile = LoxoneProfile(local("192.168.7.77"), LoxoneCredentials(USER, "pass"))
         val token = Token("token", byteArrayOf(1), TimeUtils.currentLoxoneSeconds().plus(310), 0, false)
-        val repository = InMemoryTokenRepository().apply { putToken(profile, token) }
-
-        val authenticator = LoxoneTokenAuthenticator(profile, repository)
-
-        val client = MockLoxoneClient()
-        client.stubCall(LoxoneMsg("jdev/sys/getkey2/$USER", "200", HASHING)) { it == commandForUser(USER) }
+        val (authenticator, repository) = authenticatorOf(token)
+        val client = wsClient()
 
         should("authenticate with token") {
-            val verification = client.stubCall(LoxoneMsg("authwithtoken", "200", tokenAuthResponse(TimeUtils.currentLoxoneSeconds().plus(320)))) {
-                it.pathSegments.contains("authwithtoken")
-            }
+            val verification = client.stubMsg("authwithtoken", tokenAuthResponse(TimeUtils.currentLoxoneSeconds().plus(320)))
 
             authenticator.ensureAuthenticated(client)
 
-            repository.getToken(profile).shouldNotBeNull().asClue {
+            repository.getToken(PROFILE).shouldNotBeNull().asClue {
                 it.token shouldBe token.token
                 it.key shouldBe token.key
                 it.validUntil shouldBeGreaterThan token.validUntil
@@ -41,36 +35,46 @@ class LoxoneTokenAuthenticatorTest : ShouldSpec({
         }
 
         should("kill token on close") {
-            val verification = client.stubCall(LoxoneMsg("killtoken", "401", "")) {
-                it.pathSegments.contains("killtoken")
-            }
+            val verification = client.stubMsg("killtoken", "", code = "401")
 
             authenticator.close(client)
 
-            repository.getToken(profile) shouldBe null
+            repository.getToken(PROFILE) shouldBe null
             verification.matches.size shouldBe 1
         }
     }
-    context("with refresh-needed token") {
-        val profile = LoxoneProfile(local("192.168.7.77"), LoxoneCredentials(USER, "pass"))
-        val token = Token("oldTokenValue", byteArrayOf(1), TimeUtils.currentLoxoneSeconds().plus(200), 0, false)
-        val repository = InMemoryTokenRepository().apply { putToken(profile, token) }
-        val authenticator = LoxoneTokenAuthenticator(profile, repository)
-        val client = MockLoxoneClient()
-        client.stubCall(LoxoneMsg("jdev/sys/getkey2/$USER", "200", HASHING)) { it == commandForUser(USER) }
 
-        should("refresh token and authenticate websocket") {
-            val newValidUntil = TimeUtils.currentLoxoneSeconds().plus(500)
-            val refreshVerification = client.stubCall(
-                LoxoneMsg("refreshjwt", "200", tokenRefreshResponse(newValidUntil))
-            ) { it.pathSegments.contains("refreshjwt") }
-            val authVerification = client.stubCall(
-                LoxoneMsg("authwithtoken", "200", tokenAuthResponse(TimeUtils.currentLoxoneSeconds().plus(510)))
-            ) { it.pathSegments.contains("authwithtoken") }
+    context("with no token") {
+        val (authenticator, repository) = authenticatorOf()
+        val client = wsClient()
+
+        should("request new token and authenticate websocket") {
+            val validUntil = TimeUtils.currentLoxoneSeconds().plus(400)
+            val getVerification = client.stubMsg("getjwt", token(validUntil))
 
             authenticator.ensureAuthenticated(client)
 
-            repository.getToken(profile).shouldNotBeNull().asClue {
+            repository.getToken(PROFILE).shouldNotBeNull().asClue {
+                it.token shouldBe "8E2AA590E996B321C0E17C3FA9F7A3C17BD376CC"
+                it.validUntil shouldBe validUntil
+            }
+            getVerification.matches.size shouldBe 1
+        }
+    }
+
+    context("with refresh-needed token") {
+        val token = Token("oldTokenValue", byteArrayOf(1), TimeUtils.currentLoxoneSeconds().plus(200), 0, false)
+        val (authenticator, repository) = authenticatorOf(token)
+        val client = wsClient()
+
+        should("refresh token and authenticate websocket") {
+            val newValidUntil = TimeUtils.currentLoxoneSeconds().plus(500)
+            val refreshVerification = client.stubMsg("refreshjwt", tokenRefreshResponse(newValidUntil))
+            val authVerification = client.stubMsg("authwithtoken", tokenAuthResponse(TimeUtils.currentLoxoneSeconds().plus(510)))
+
+            authenticator.ensureAuthenticated(client)
+
+            repository.getToken(PROFILE).shouldNotBeNull().asClue {
                 it.token shouldBe "REFRESHED_TOKEN_VALUE"
                 it.key shouldBe token.key
                 it.validUntil shouldBeGreaterThan newValidUntil
@@ -79,8 +83,73 @@ class LoxoneTokenAuthenticatorTest : ShouldSpec({
             authVerification.matches.size shouldBe 1
         }
     }
+
+    context("with refresh-needed token and http client") {
+        val token = Token("oldTokenValue", byteArrayOf(1), TimeUtils.currentLoxoneSeconds().plus(200), 0, false)
+        val (authenticator, repository) = authenticatorOf(token)
+        val client = httpClient()
+
+        should("refresh token without authwithtoken") {
+            val newValidUntil = TimeUtils.currentLoxoneSeconds().plus(500)
+            val refreshVerification = client.stubMsg("refreshjwt", tokenRefreshResponse(newValidUntil))
+
+            authenticator.ensureAuthenticated(client)
+
+            repository.getToken(PROFILE).shouldNotBeNull().asClue {
+                it.token shouldBe "REFRESHED_TOKEN_VALUE"
+                it.key shouldBe token.key
+                it.validUntil shouldBe newValidUntil
+            }
+            refreshVerification.matches.size shouldBe 1
+        }
+    }
+
+    context("with already authenticated websocket") {
+        val (authenticator, repository) = authenticatorOf(
+            Token("token", byteArrayOf(1), TimeUtils.currentLoxoneSeconds().plus(400), 0, false)
+        )
+        val client = wsClient()
+
+        should("not re-authenticate on second call") {
+            client.stubMsg("authwithtoken", tokenAuthResponse(TimeUtils.currentLoxoneSeconds().plus(450)))
+
+            authenticator.ensureAuthenticated(client)
+            authenticator.ensureAuthenticated(client)
+
+            repository.getToken(PROFILE).shouldNotBeNull()
+        }
+    }
+
+    context("with killTokenOnClose disabled") {
+        val initialToken = Token("token", byteArrayOf(1), TimeUtils.currentLoxoneSeconds().plus(400), 0, false)
+        val (authenticator, repository) = authenticatorOf(initialToken, LoxoneClientSettings(killTokenOnClose = false))
+
+        should("not kill token on close") {
+            authenticator.close(MockLoxoneClient())
+
+            repository.getToken(PROFILE) shouldBe initialToken
+        }
+    }
+
 }) {
     companion object {
         const val USER = "someUserName"
+        val PROFILE = LoxoneProfile(local("192.168.7.77"), LoxoneCredentials(USER, "pass"))
+
+        internal fun wsClient() = MockLoxoneClient().apply {
+            stubCall(LoxoneMsg("jdev/sys/getkey2/$USER", "200", HASHING)) { it == commandForUser(USER) }
+        }
+
+        internal fun httpClient() = MockHttpLoxoneClient().apply {
+            stubCall(LoxoneMsg("jdev/sys/getkey2/$USER", "200", HASHING)) { it == commandForUser(USER) }
+        }
+
+        internal fun authenticatorOf(
+            token: Token? = null,
+            settings: LoxoneClientSettings = LoxoneClientSettings()
+        ): Pair<LoxoneTokenAuthenticator, InMemoryTokenRepository> {
+            val repository = InMemoryTokenRepository().also { if (token != null) it.putToken(PROFILE, token) }
+            return LoxoneTokenAuthenticator(PROFILE, repository, settings) to repository
+        }
     }
 }

--- a/src/commonTest/kotlin/LoxoneTokenAuthenticatorTest.kt
+++ b/src/commonTest/kotlin/LoxoneTokenAuthenticatorTest.kt
@@ -5,6 +5,7 @@ import cz.smarteon.loxkt.message.Hashing.Companion.commandForUser
 import cz.smarteon.loxkt.message.LoxoneMsg
 import cz.smarteon.loxkt.message.TestingLoxValues.HASHING
 import cz.smarteon.loxkt.message.TestingLoxValues.tokenAuthResponse
+import cz.smarteon.loxkt.message.TestingLoxValues.tokenRefreshResponse
 import cz.smarteon.loxkt.message.Token
 import io.kotest.assertions.asClue
 import io.kotest.core.spec.style.ShouldSpec
@@ -48,6 +49,34 @@ class LoxoneTokenAuthenticatorTest : ShouldSpec({
 
             repository.getToken(profile) shouldBe null
             verification.matches.size shouldBe 1
+        }
+    }
+    context("with refresh-needed token") {
+        val profile = LoxoneProfile(local("192.168.7.77"), LoxoneCredentials(USER, "pass"))
+        val token = Token("oldTokenValue", byteArrayOf(1), TimeUtils.currentLoxoneSeconds().plus(200), 0, false)
+        val repository = InMemoryTokenRepository().apply { putToken(profile, token) }
+        val authenticator = LoxoneTokenAuthenticator(profile, repository)
+        val client = MockLoxoneClient()
+        client.stubCall(LoxoneMsg("jdev/sys/getkey2/$USER", "200", HASHING)) { it == commandForUser(USER) }
+
+        should("refresh token and authenticate websocket") {
+            val newValidUntil = TimeUtils.currentLoxoneSeconds().plus(500)
+            val refreshVerification = client.stubCall(
+                LoxoneMsg("refreshjwt", "200", tokenRefreshResponse(newValidUntil))
+            ) { it.pathSegments.contains("refreshjwt") }
+            val authVerification = client.stubCall(
+                LoxoneMsg("authwithtoken", "200", tokenAuthResponse(TimeUtils.currentLoxoneSeconds().plus(510)))
+            ) { it.pathSegments.contains("authwithtoken") }
+
+            authenticator.ensureAuthenticated(client)
+
+            repository.getToken(profile).shouldNotBeNull().asClue {
+                it.token shouldBe "REFRESHED_TOKEN_VALUE"
+                it.key shouldBe token.key
+                it.validUntil shouldBeGreaterThan newValidUntil
+            }
+            refreshVerification.matches.size shouldBe 1
+            authVerification.matches.size shouldBe 1
         }
     }
 }) {

--- a/src/commonTest/kotlin/MockLoxoneClient.kt
+++ b/src/commonTest/kotlin/MockLoxoneClient.kt
@@ -1,6 +1,7 @@
 package cz.smarteon.loxkt
 
 import cz.smarteon.loxkt.event.LoxoneEvent
+import cz.smarteon.loxkt.message.LoxoneMsg
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 
@@ -17,6 +18,9 @@ internal class MockLoxoneClient : WebsocketLoxoneClient {
         stubbedCalls.add(StubbedCall(commandMatcher, response, verification))
         return verification
     }
+
+    fun stubMsg(operation: String, value: String, code: String = "200") =
+        stubCall(LoxoneMsg(operation, code, value)) { it.pathSegments.contains(operation) }
 
     fun stubRawData(command: String, data: ByteArray) {
         stubbedRawData[command] = data
@@ -44,6 +48,38 @@ internal class MockLoxoneClient : WebsocketLoxoneClient {
     override suspend fun close() {
         TODO("Not yet implemented")
     }
+}
+
+internal class MockHttpLoxoneClient : LoxoneClient {
+
+    private val stubbedCalls = mutableListOf<StubbedCall<*>>()
+
+    fun <RESPONSE : LoxoneResponse> stubCall(
+        response: RESPONSE,
+        commandMatcher: (Command<*>) -> Boolean
+    ): CallVerification {
+        val verification = CallVerification()
+        stubbedCalls.add(StubbedCall(commandMatcher, response, verification))
+        return verification
+    }
+
+    override suspend fun <RESPONSE : LoxoneResponse> call(command: Command<RESPONSE>): RESPONSE {
+        stubbedCalls.firstOrNull { it.commandMatcher(command) }?.let {
+            it.verification.matches.add(command)
+
+            @Suppress("UNCHECKED_CAST")
+            return it.response as RESPONSE
+        } ?: error("No stubbed call for $command")
+    }
+
+    fun stubMsg(operation: String, value: String, code: String = "200") =
+        stubCall(LoxoneMsg(operation, code, value)) { it.pathSegments.contains(operation) }
+
+    override suspend fun callRaw(command: String): String = error("Not stubbed")
+
+    override suspend fun callRawForData(command: String): ByteArray = error("Not stubbed")
+
+    override suspend fun close() {}
 }
 
 internal data class StubbedCall<RESPONSE : LoxoneResponse>(

--- a/src/commonTest/kotlin/message/TestingMessages.kt
+++ b/src/commonTest/kotlin/message/TestingMessages.kt
@@ -49,4 +49,14 @@ internal object TestingLoxValues {
             }
         """.trimIndent()
 
+    fun tokenRefreshResponse(validUntil: Long) =
+        // language=JSON
+        """
+            {
+              "token": "REFRESHED_TOKEN_VALUE",
+              "validUntil": $validUntil,
+              "unsecurePass": false
+            }
+        """.trimIndent()
+
 }

--- a/src/commonTest/kotlin/message/TokenTest.kt
+++ b/src/commonTest/kotlin/message/TokenTest.kt
@@ -6,6 +6,8 @@ import cz.smarteon.loxkt.message.TestingLoxValues.tokenAuthResponse
 import cz.smarteon.loxkt.message.TestingLoxValues.tokenRefreshResponse
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.encodeToString
 
 class TokenTest : StringSpec({
 
@@ -60,5 +62,46 @@ class TokenTest : StringSpec({
             1666,
             false
         )
+    }
+
+    "should merge equal token returning same instance" {
+        val t = loxJson.decodeFromString<Token>(token(342151839))
+        t.merge(t) shouldBe t
+    }
+
+    "should merge token with non-null incoming key" {
+        val noKey = Token(null, null, 342151839, null, false)
+        val withKey = loxJson.decodeFromString<Token>(token(342151900))
+        noKey.merge(withKey).key shouldBe withKey.key
+    }
+
+    "should not equal tokens differing by field" {
+        val base = loxJson.decodeFromString<Token>(token(342151839))
+        base shouldNotBe base.copy(key = byteArrayOf(1))
+        base shouldNotBe base.copy(validUntil = 999L)
+        base shouldNotBe base.copy(rights = 999)
+        base shouldNotBe base.copy(unsecurePassword = true)
+    }
+
+    "should equal same reference and not equal null or other type" {
+        val t = loxJson.decodeFromString<Token>(token(342151839))
+        (t == t) shouldBe true
+        t.equals(null) shouldBe false
+        t.equals("not a token") shouldBe false
+    }
+
+    "should compute consistent hashCode" {
+        val full = loxJson.decodeFromString<Token>(token(342151839))
+        val nullFields = loxJson.decodeFromString<Token>(tokenAuthResponse(342151839))
+        val nullRights = loxJson.decodeFromString<Token>(tokenRefreshResponse(342151839))
+        full.hashCode() shouldBe full.hashCode()
+        full.hashCode() shouldNotBe nullFields.hashCode()
+        nullFields.hashCode() shouldNotBe 0
+        nullRights.hashCode() shouldNotBe 0
+    }
+
+    "should serialize and deserialize roundtrip" {
+        val t = loxJson.decodeFromString<Token>(tokenAuthResponse(342151839))
+        loxJson.decodeFromString<Token>(loxJson.encodeToString(t)) shouldBe t
     }
 })

--- a/src/commonTest/kotlin/message/TokenTest.kt
+++ b/src/commonTest/kotlin/message/TokenTest.kt
@@ -3,6 +3,7 @@ package cz.smarteon.loxkt.message
 import cz.smarteon.loxkt.Codec.loxJson
 import cz.smarteon.loxkt.message.TestingLoxValues.token
 import cz.smarteon.loxkt.message.TestingLoxValues.tokenAuthResponse
+import cz.smarteon.loxkt.message.TestingLoxValues.tokenRefreshResponse
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
@@ -36,6 +37,28 @@ class TokenTest : StringSpec({
             342151900,
             1667,
             true
+        )
+    }
+
+    "should deserialize refresh response" {
+        loxJson.decodeFromString<Token>(tokenRefreshResponse(342151839)) shouldBe Token(
+            "REFRESHED_TOKEN_VALUE",
+            null,
+            342151839,
+            null,
+            false
+        )
+    }
+
+    "should merge refresh response preserving rights" {
+        val original = Token("origToken", byteArrayOf(1), 342151839, 1666, false)
+        val refreshResponse = loxJson.decodeFromString<Token>(tokenRefreshResponse(342151900))
+        original.merge(refreshResponse) shouldBe Token(
+            "REFRESHED_TOKEN_VALUE",
+            byteArrayOf(1),
+            342151900,
+            1666,
+            false
         )
     }
 })

--- a/src/jvmAcceptanceTest/kotlin/LoxoneClientAT.kt
+++ b/src/jvmAcceptanceTest/kotlin/LoxoneClientAT.kt
@@ -6,6 +6,8 @@ import cz.smarteon.loxkt.message.ApiInfo
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.spec.style.wordSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldMatch
@@ -24,6 +26,31 @@ fun commonAT(loxoneClient: LoxoneClient) = wordSpec {
         }
         "callForMsg ApiInfo" {
             loxoneClient.callForMsg(ApiInfo.command).version shouldMatch ".*\\d+\\.\\d+\\.\\d+.*"
+        }
+    }
+}
+
+/**
+ * Acceptance tests for WebSocket-specific functionality.
+ * @param client WebSocket client to test
+ * @param authenticator authenticator backing the client
+ * @param user Loxone username
+ */
+fun websocketAT(
+    client: KtorWebsocketLoxoneClient,
+    authenticator: LoxoneTokenAuthenticator,
+    user: String
+) = wordSpec {
+    "KtorWebsocketLoxoneClient" When {
+        "WebSocket token" should {
+            "be refreshable via refreshjwt" {
+                client.callForMsg(ApiInfo.command)
+                val refreshed = client.callForMsg(
+                    LoxoneCommands.Tokens.refresh(authenticator.tokenHash(client, "refreshjwt"), user)
+                )
+                refreshed.validUntil shouldBeGreaterThan 0L
+                refreshed.token.shouldNotBeNull()
+            }
         }
     }
 }
@@ -51,6 +78,7 @@ class LoxoneClientAT : WordSpec() {
 
         include(commonAT(httpClient))
         include(commonAT(websocketClient))
+        include(websocketAT(websocketClient, authenticator, user))
     }
 
     private fun getLoxEnv(name: String) = "LOX_$name".let { requireNotNull(System.getenv(it)) { "Please set $it env" } }


### PR DESCRIPTION
Closes #27

## Summary

- Adds `Tokens.refresh(tokenHash, user)` command — `jdev/sys/refreshjwt/{tokenHash}/{user}` with `authenticated = false` (avoids mutex re-entry deadlock from inside `ensureAuthenticated`)
- Implements the `needsRefresh` branch in `LoxoneTokenAuthenticator`: HMAC the stored token against the already-fetched `hashing`, call `refreshjwt`, merge the response, then call `authwithtoken` to establish WebSocket session auth before adding to `authWebsockets`
- Uses the modern JWT endpoint (`refreshjwt`), not the deprecated legacy `refreshtoken`

## Test plan

- [ ] `LoxoneCommandsTest` — asserts path segments, `authenticated = false`, return type
- [ ] `LoxoneTokenAuthenticatorTest` — token expiring in 200 s (inside needsRefresh window); verifies both `refreshjwt` and `authwithtoken` are called, refreshed token value and original key survive both merges
- [ ] `LoxoneClientAT` — calls `refreshjwt` directly on a real Miniserver after initial auth; also confirms the `"refreshjwt"` HMAC operation name

🤖 Generated with [Claude Code](https://claude.com/claude-code)