### PR TITLE
ci: run acceptance tests in pre-merge workflow

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -1,0 +1,42 @@
+---
+name: Acceptance Test
+
+# Runs the acceptance tests (jvmAcceptanceTest) against a real Loxone Miniserver.
+# Requires the Miniserver to be reachable from the runner and the LOX_* secrets to be set.
+on:
+  workflow_call:
+    secrets:
+      GRADLE_ENCRYPTION_KEY:
+        required: true
+      LOX_ADDRESS:
+        required: true
+      LOX_USER:
+        required: true
+      LOX_PASS:
+        required: true
+  workflow_dispatch:
+
+jobs:
+  acceptance-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Run acceptance tests
+        env:
+          LOX_ADDRESS: ${{ secrets.LOX_ADDRESS }}
+          LOX_USER: ${{ secrets.LOX_USER }}
+          LOX_PASS: ${{ secrets.LOX_PASS }}
+        run: ./gradlew jvmAcceptanceTest

--- a/.github/workflows/required-status-checks.yml
+++ b/.github/workflows/required-status-checks.yml
@@ -59,6 +59,15 @@ jobs:
     uses: ./.github/workflows/check.yml
     secrets: inherit
 
+  # Run acceptance tests against a real Miniserver if client code changed.
+  # Informational only - not wired into required-checks-result, so it never blocks a merge.
+  acceptance-test:
+    name: Acceptance test (informational)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.loxone-client == 'true'
+    uses: ./.github/workflows/acceptance-test.yml
+    secrets: inherit
+
   # Run Kotlin example check if needed
   kotlin-example-check:
     name: Kotlin example check


### PR DESCRIPTION
Add a reusable acceptance-test workflow that runs jvmAcceptanceTest against a real Miniserver, and wire it into required-status-checks gated on the loxone-client paths filter. Informational only - it is not part of required-checks-result, so it never blocks a merge.

Requires LOX_ADDRESS, LOX_USER and LOX_PASS repo secrets.