### PR TITLE
feat(crypto): AES command encryption and WebSocket key exchange (#76)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,6 +178,7 @@ kotlin {
         jsMain.dependencies {
             implementation(libs.ktor.client.js)
             implementation(npm("jsencrypt", "3.3.2"))
+            implementation(npm("crypto-js", "4.2.0"))
         }
         linuxMain.get().dependsOn(nativeJvmMain)
         linuxMain.dependencies {

--- a/docs/protocol-gap-analysis.md
+++ b/docs/protocol-gap-analysis.md
@@ -107,7 +107,7 @@ The library currently implements core authentication (token-based), basic WebSoc
 - Note: Separate documentation exists for structure file format
 
 #### 4. Command Encryption
-**Status:** Not Implemented  
+**Status:** Implemented (WebSocket)  
 **Impact:** High - Required for secure command transmission  
 **Protocol Reference:** CommunicatingWithMiniserver.md, "Command Encryption"
 
@@ -115,17 +115,38 @@ The library currently implements core authentication (token-based), basic WebSoc
 - Public key retrieval: `jdev/sys/getPublicKey` ✅
 - RSA encryption (PKCS1v1.5, Base64 NoWrap), multiplatform ✅
 
-**Missing Components:**
-- AES-256-CBC key + IV generation (random, 32-byte key / 16-byte IV)
-- AES-256-CBC encryption with ZeroBytePadding
-- Key exchange: `jdev/sys/keyexchange/{encrypted-session-key}`
-- Encrypted command wrapping: `jdev/sys/enc/{cipher}`
-- Encrypted command with encrypted response: `jdev/sys/fenc/{cipher}`
-- Session salt rotation (anti-replay) per command
+**Implemented (#76):**
+- AES-256-CBC key + IV generation (random, 32-byte key / 16-byte IV), multiplatform ✅
+- AES-256-CBC encryption/decryption with ZeroBytePadding ✅
+- Key exchange: `jdev/sys/keyexchange/{encrypted-session-key}` ✅
+- Encrypted command wrapping: `jdev/sys/enc/{cipher}` ✅
+- Encrypted command with encrypted response: `jdev/sys/fenc/{cipher}` ✅
+- Session salt rotation (anti-replay) per command ✅
+- Mandatory encryption of token acquisition (`getjwt`/`authwithtoken`); opt-in
+  `CommandEncryption` mode (NONE/REQUEST/REQUEST_RESPONSE) for all other commands ✅
+- Public key fetched over **HTTP** (`jdev/sys/getPublicKey` is rejected on the websocket with 400);
+  the Miniserver returns it wrapped in `-----BEGIN CERTIFICATE-----` markers, normalized to a
+  `PUBLIC KEY` PEM by `LoxoneCrypto.normalizePublicKeyPem` ✅
+
+**Remaining / known limitations:**
+- HTTP command encryption (`?sk=` session-key query form) — only the WebSocket channel is wired
+- Public key caching via `PublicKeyRepository` (currently fetched once per session); note the
+  dormant `PublicKey` message model from PR #75 assumes a `{"publicKey":...}` object value and is
+  unused by the websocket flow
+- `REQUEST_RESPONSE` (fenc) mode is unsafe with binary/large responses (images, files, `LoxAPP3.json`)
+  — the Miniserver only supports `enc` for those
+- No reconnect: after `close()` (incl. keepalive timeout) the client is single-use
+- The JS `actual` (crypto-js) is not exercised by tests (the JS test task is disabled); the common
+  AES roundtrip would cover it once a JS test target is enabled
+- **Fixed AES-CBC IV**: the IV is generated once and reused for the entire session. Salt rotation
+  provides per-command plaintext uniqueness, but reusing the same key+IV in AES-CBC is a protocol
+  limitation — the Miniserver's key-exchange API does not support IV rotation.
 
 **Current Code Reference:**
-- `src/commonMain/kotlin/LoxoneCrypto.kt` — hashing + RSA; AES not yet implemented
-- `src/commonMain/kotlin/PublicKey.kt` — public key model
+- `src/commonMain/kotlin/LoxoneCrypto.kt` — hashing, RSA + AES (`aesEncrypt`/`aesDecrypt`)
+- `src/commonMain/kotlin/ktor/KtorWebsocketLoxoneClient.kt` — key exchange + enc/fenc wrapping
+- `src/commonMain/kotlin/LoxoneClientSettings.kt` — `CommandEncryption` setting
+- `src/commonMain/kotlin/message/PublicKey.kt` — public key model
 - `src/commonMain/kotlin/PublicKeyRepository.kt` — key caching
 
 ---

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
+crypto-js@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
+
 format-util@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"

--- a/src/commonMain/kotlin/Command.kt
+++ b/src/commonMain/kotlin/Command.kt
@@ -12,6 +12,14 @@ interface Command<out RESPONSE : LoxoneResponse> {
     val responseType: KClass<out RESPONSE>
 
     val authenticated: Boolean
+
+    /**
+     * Whether this command must be sent over the encrypted command channel (`jdev/sys/enc/`)
+     * regardless of the client's global command encryption setting. Required for commands the
+     * Miniserver only accepts encrypted, e.g. token acquisition (`getjwt`).
+     */
+    val encrypted: Boolean
+        get() = false
 }
 
 /**

--- a/src/commonMain/kotlin/LoxoneClientSettings.kt
+++ b/src/commonMain/kotlin/LoxoneClientSettings.kt
@@ -14,3 +14,25 @@ data class LoxoneClientSettings @JvmOverloads constructor(
         const val DEFAULT_CLIENT_INFO = "loxoneKotlin"
     }
 }
+
+/**
+ * Controls how commands are encrypted before being sent to the Miniserver.
+ *
+ * Note that commands which the Miniserver only accepts encrypted (e.g. token acquisition, see
+ * [Command.encrypted]) are always encrypted regardless of this setting.
+ */
+enum class CommandEncryption {
+    /** No general command encryption; only commands explicitly requiring it are encrypted. */
+    NONE,
+
+    /** Encrypt every command via `jdev/sys/enc/`; responses are returned as plain text. */
+    REQUEST,
+
+    /**
+     * Encrypt every command via `jdev/sys/fenc/`; responses are AES-encrypted and decrypted by the client.
+     *
+     * Not suitable for commands returning binary/large payloads (images, files, `LoxAPP3.json`): the
+     * Miniserver only supports `enc` for those, and the encrypted-response path expects a text frame.
+     */
+    REQUEST_RESPONSE
+}

--- a/src/commonMain/kotlin/LoxoneCommands.kt
+++ b/src/commonMain/kotlin/LoxoneCommands.kt
@@ -56,7 +56,9 @@ object LoxoneCommands {
             permission.id.toString(),
             clientId,
             clientInfo,
-            authenticated = false
+            authenticated = false,
+            // getjwt must be sent over the encrypted channel; a Miniserver declines plain getjwt with 400
+            encrypted = true
         )
 
         /**
@@ -68,7 +70,8 @@ object LoxoneCommands {
         fun auth(tokenHash: String, user: String) = SimpleLoxoneMsgCommand(
             listOf("authwithtoken", tokenHash, user),
             Token::class,
-            authenticated = false
+            authenticated = false,
+            encrypted = true
         )
 
         /**

--- a/src/commonMain/kotlin/LoxoneCrypto.kt
+++ b/src/commonMain/kotlin/LoxoneCrypto.kt
@@ -15,13 +15,84 @@ import org.kotlincrypto.macs.hmac.sha2.HmacSHA256
 
 internal expect fun rsaEncryptBytes(data: ByteArray, publicKeyPem: String): ByteArray
 
+/**
+ * AES-256-CBC encryption with no padding applied by the platform. The [data] must be a multiple of
+ * the 16-byte AES block size - [LoxoneCrypto] applies ZeroBytePadding before calling this.
+ */
+internal expect fun aesEncryptBytes(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray
+
+/** AES-256-CBC decryption counterpart of [aesEncryptBytes], also without padding handling. */
+internal expect fun aesDecryptBytes(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray
+
+/** Returns [size] cryptographically secure random bytes. */
+internal expect fun secureRandomBytes(size: Int): ByteArray
+
 internal object LoxoneCrypto {
 
     private val logger = KotlinLogging.logger {}
 
+    private const val AES_KEY_SIZE = 32
+    private const val AES_IV_SIZE = 16
+    private const val AES_BLOCK_SIZE = 16
+    private const val SALT_SIZE = 2
+    private const val PEM_LINE_LENGTH = 64
+    private val PEM_HEADER_FOOTER = Regex("-+(?:BEGIN|END) (?:CERTIFICATE|PUBLIC KEY)-+")
+    private val WHITESPACE = Regex("\\s")
+
     @OptIn(ExperimentalEncodingApi::class)
     internal fun rsaEncrypt(data: String, publicKeyPem: String): String =
         Base64.encode(rsaEncryptBytes(data.encodeToByteArray(), publicKeyPem))
+
+    /**
+     * Normalizes the public key returned by `jdev/sys/getPublicKey` into a standard
+     * `-----BEGIN PUBLIC KEY-----` PEM. The Miniserver wraps the SubjectPublicKeyInfo in
+     * `-----BEGIN CERTIFICATE-----` markers (and may omit line breaks), which the RSA decoders
+     * don't accept as-is, so we strip the markers/whitespace and re-wrap the base64 body.
+     */
+    internal fun normalizePublicKeyPem(raw: String): String {
+        val base64 = raw.replace(PEM_HEADER_FOOTER, "").replace(WHITESPACE, "")
+        val wrapped = base64.chunked(PEM_LINE_LENGTH).joinToString("\n")
+        return "-----BEGIN PUBLIC KEY-----\n$wrapped\n-----END PUBLIC KEY-----"
+    }
+
+    /**
+     * AES-256-CBC encrypts the given [plaintext] using [key] and [iv], applying Loxone's
+     * ZeroBytePadding (pad to a 16-byte boundary with `0x00`), and returns the Base64 encoded result.
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    internal fun aesEncrypt(plaintext: String, key: ByteArray, iv: ByteArray): String {
+        val bytes = plaintext.encodeToByteArray()
+        val padding = (AES_BLOCK_SIZE - bytes.size % AES_BLOCK_SIZE) % AES_BLOCK_SIZE
+        val padded = if (padding == 0) bytes else bytes.copyOf(bytes.size + padding)
+        return Base64.encode(aesEncryptBytes(padded, key, iv))
+    }
+
+    /**
+     * Decrypts the Base64 encoded AES-256-CBC [base64Cipher] using [key] and [iv] and strips the
+     * trailing ZeroBytePadding. Counterpart of [aesEncrypt].
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    internal fun aesDecrypt(base64Cipher: String, key: ByteArray, iv: ByteArray): String =
+        aesDecryptBytes(Base64.decode(base64Cipher), key, iv).decodeToString().trimEnd('\u0000')
+
+    /** Generates a random 32-byte (256-bit) AES key. */
+    internal fun generateAesKey(): ByteArray = secureRandomBytes(AES_KEY_SIZE)
+
+    /** Generates a random 16-byte AES initialization vector. */
+    internal fun generateAesIv(): ByteArray = secureRandomBytes(AES_IV_SIZE)
+
+    /**
+     * Generates a random salt as a hex string used for command encryption (anti-replay).
+     * Note this is not the user salt obtained via the getkey2 command.
+     */
+    internal fun generateSalt(): String = bytesToHex(secureRandomBytes(SALT_SIZE))
+
+    /**
+     * Builds the RSA-encrypted session key to exchange with the Miniserver. The AES [key] and [iv]
+     * are hex encoded and joined as `"{keyHex}:{ivHex}"`, then RSA encrypted with [publicKeyPem].
+     */
+    internal fun createSessionKey(key: ByteArray, iv: ByteArray, publicKeyPem: String): String =
+        rsaEncrypt(concat(bytesToHex(key), bytesToHex(iv)), publicKeyPem)
 
     /**
      * Performs hashing algorithm as required by loxone specification.

--- a/src/commonMain/kotlin/ktor/KtorWebsocketLoxoneClient.kt
+++ b/src/commonMain/kotlin/ktor/KtorWebsocketLoxoneClient.kt
@@ -3,17 +3,23 @@ package cz.smarteon.loxkt.ktor
 import cz.smarteon.loxkt.Codec
 import cz.smarteon.loxkt.Codec.loxJson
 import cz.smarteon.loxkt.Command
+import cz.smarteon.loxkt.CommandEncryption
 import cz.smarteon.loxkt.LoxoneCommands
+import cz.smarteon.loxkt.LoxoneCrypto
 import cz.smarteon.loxkt.LoxoneEndpoint
+import cz.smarteon.loxkt.LoxoneException
 import cz.smarteon.loxkt.LoxoneResponse
 import cz.smarteon.loxkt.LoxoneTokenAuthenticator
 import cz.smarteon.loxkt.WebsocketLoxoneClient
 import cz.smarteon.loxkt.event.LoxoneEvent
+import cz.smarteon.loxkt.message.LoxoneMsg
 import cz.smarteon.loxkt.message.MessageHeader
 import cz.smarteon.loxkt.message.MessageKind
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.websocket.*
 import io.ktor.websocket.CloseReason.Codes.*
@@ -34,14 +40,17 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.concurrent.Volatile
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("TooManyFunctions")
 class KtorWebsocketLoxoneClient internal constructor(
     private val client: HttpClient,
     private val endpoint: LoxoneEndpoint? = null,
     private val authenticator: LoxoneTokenAuthenticator? = null,
+    private val commandEncryption: CommandEncryption = CommandEncryption.NONE,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
     eventBufferSize: Int = DEFAULT_EVENT_BUFFER_SIZE
 ) : WebsocketLoxoneClient {
@@ -49,13 +58,31 @@ class KtorWebsocketLoxoneClient internal constructor(
     @JvmOverloads constructor(
         endpoint: LoxoneEndpoint,
         authenticator: LoxoneTokenAuthenticator? = null,
+        commandEncryption: CommandEncryption = CommandEncryption.NONE,
         eventBufferSize: Int = DEFAULT_EVENT_BUFFER_SIZE
-    ) : this(HttpClient { install(WebSockets) }, endpoint, authenticator, Dispatchers.Default, eventBufferSize)
+    ) : this(
+        HttpClient { install(WebSockets) },
+        endpoint,
+        authenticator,
+        commandEncryption,
+        Dispatchers.Default,
+        eventBufferSize
+    )
 
     private val logger = KotlinLogging.logger {}
 
     private val sessionMutex = Mutex()
     private var session: ClientWebSocketSession? = null
+
+    /** Serializes the send + receive (+ salt rotation) of a single command over the socket. */
+    private val callMutex = Mutex()
+
+    /** Guards the one-time command-encryption key exchange per session. */
+    private val keyExchangeMutex = Mutex()
+    // @Volatile so the fast-path (unsynchronized) reads in the double-checked key exchange and the
+    // reads under callMutex safely observe the values published under keyExchangeMutex.
+    @Volatile private var sessionKey: SessionKey? = null
+    @Volatile private var publicKey: String? = null
 
     /**
      * Scope used for all background tasks in the client. Should not be used for executing commands (call* functions).
@@ -71,23 +98,123 @@ class KtorWebsocketLoxoneClient internal constructor(
     override val events: SharedFlow<LoxoneEvent> = _events.asSharedFlow()
 
     override suspend fun <RESPONSE : LoxoneResponse> call(command: Command<RESPONSE>): RESPONSE {
-        val session = ensureSession()
+        ensureSession()
+        // Key exchange must precede authentication: the token commands are encrypted and the
+        // Miniserver rejects a key exchange started mid-authentication.
+        val willAuthenticate = command.authenticated && authenticator != null
+        if (commandEncryption != CommandEncryption.NONE || command.encrypted || willAuthenticate) {
+            ensureKeyExchange()
+        }
         if (command.authenticated) {
             authenticator?.ensureAuthenticated(this)
         }
 
-        session.send(command)
+        val response = exchange(command.pathSegments.joinToString(separator = "/"), command.encrypted)
 
         @Suppress("UNCHECKED_CAST")
-        return loxJson.decodeFromString(command.responseType.deserializer, receiveTextMessage()) as RESPONSE
+        return loxJson.decodeFromString(command.responseType.deserializer, response) as RESPONSE
     }
 
     override suspend fun callRaw(command: String): String {
-        val session = ensureSession()
+        ensureSession()
+        // callRaw always authenticates (when an authenticator is present), so key exchange may be needed.
+        if (commandEncryption != CommandEncryption.NONE || authenticator != null) {
+            ensureKeyExchange()
+        }
         authenticator?.ensureAuthenticated(this)
-        logger.trace { "Sending command: $command" }
-        session.send(command)
-        return receiveTextMessage()
+        return exchange(command, forceEncrypt = false)
+    }
+
+    /**
+     * Wraps (encrypting if required), sends [plain] and receives the response, decrypting it when the
+     * command was sent over the `fenc` channel. Serialized via [callMutex] because salt rotation and
+     * the single-slot response channels require one in-flight command at a time.
+     */
+    private suspend fun exchange(plain: String, forceEncrypt: Boolean): String = callMutex.withLock {
+        val ws = checkNotNull(session) { "WebSocketSession should not be null" }
+        val wrapped = wrap(plain, forceEncrypt)
+        logger.trace { "Sending command: ${wrapped.wire}" }
+        ws.send(wrapped.wire)
+        val raw = receiveTextMessage()
+        // Advance the salt only after a successful round-trip, so a failed send/receive doesn't
+        // leave the client's salt ahead of what the Miniserver accepted.
+        wrapped.saltToCommit?.let { sessionKey?.commitSalt(it) }
+        if (wrapped.responseEncrypted) {
+            val sk = checkNotNull(sessionKey) { "Session key missing for encrypted response" }
+            LoxoneCrypto.aesDecrypt(raw, sk.aesKey, sk.iv)
+        } else {
+            raw
+        }
+    }
+
+    /**
+     * Builds the wire form of [plain]: either the plain command, or the AES-encrypted
+     * `jdev/sys/enc/` (response plain) / `jdev/sys/fenc/` (response encrypted) form. Bootstrap
+     * the keyexchange command is never encrypted.
+     */
+    private fun wrap(plain: String, forceEncrypt: Boolean): WrappedCommand {
+        val mustEncrypt = forceEncrypt || commandEncryption != CommandEncryption.NONE
+        val neverEncrypt = plain.startsWith(KEY_EXCHANGE_PREFIX)
+        if (!mustEncrypt || neverEncrypt) return WrappedCommand(plain, responseEncrypted = false)
+
+        val sk = checkNotNull(sessionKey) { "Key exchange must complete before encrypting commands" }
+        val (saltPart, nextSalt) = sk.nextSaltPart()
+        val cipher = LoxoneCrypto.aesEncrypt("$saltPart/$plain", sk.aesKey, sk.iv)
+        // Commands that are mandatorily encrypted (e.g. token acquisition) use the enc channel; only
+        // general commands honour REQUEST_RESPONSE to also get an encrypted response (fenc).
+        val useFenc = commandEncryption == CommandEncryption.REQUEST_RESPONSE && !forceEncrypt
+        val prefix = if (useFenc) FENC_PREFIX else ENC_PREFIX
+        return WrappedCommand(
+            wire = prefix + cipher.encodeURLParameter(),
+            responseEncrypted = useFenc,
+            saltToCommit = nextSalt
+        )
+    }
+
+    /**
+     * Performs the one-time command-encryption key exchange for the current session: fetches the
+     * Miniserver public key (over HTTP - it is not available on the websocket channel), generates the
+     * AES key/iv, and RSA-exchanges them over the websocket.
+     */
+    private suspend fun ensureKeyExchange() {
+        if (sessionKey != null) return
+        keyExchangeMutex.withLock {
+            if (sessionKey != null) return
+            val pem = publicKey ?: fetchPublicKey().also { publicKey = it }
+            val key = LoxoneCrypto.generateAesKey()
+            val iv = LoxoneCrypto.generateAesIv()
+            // The session key is passed as raw Base64 - unlike enc/fenc ciphers, the keyexchange
+            // command is not URI-component-encoded (matches the protocol docs and loxone-java).
+            val encryptedSessionKey = LoxoneCrypto.createSessionKey(key, iv, pem)
+            val response = exchange("$KEY_EXCHANGE_PREFIX$encryptedSessionKey", forceEncrypt = false)
+            val msg = loxJson.decodeFromString<LoxoneMsg>(response)
+            if (msg.code != LoxoneMsg.CODE_OK) throw LoxoneException("Key exchange failed with code ${msg.code}")
+            logger.debug { "Command encryption key exchange completed" }
+            sessionKey = SessionKey(key, iv)
+        }
+    }
+
+    /**
+     * Fetches the Miniserver public key over HTTP (`jdev/sys/getPublicKey` is rejected on the
+     * websocket channel) and normalizes the certificate-wrapped value to a usable PUBLIC KEY PEM.
+     */
+    private suspend fun fetchPublicKey(): String {
+        val keyResponse = client.get {
+            url {
+                endpoint?.let {
+                    protocol = if (it.useSsl) URLProtocol.HTTPS else URLProtocol.HTTP
+                    host = it.host
+                    port = it.port
+                    encodedPath = it.path.trimEnd('/') + GET_PUBLIC_KEY_PATH
+                } ?: run { encodedPath = GET_PUBLIC_KEY_PATH }
+            }
+        }.bodyAsText()
+        val keyMsg = loxJson.decodeFromString<LoxoneMsg>(keyResponse)
+        if (keyMsg.code != LoxoneMsg.CODE_OK) {
+            throw LoxoneException("Failed to retrieve public key, code ${keyMsg.code}")
+        }
+        // value is a plain (certificate-wrapped) string, not a {"publicKey":...} object
+        return LoxoneCrypto.normalizePublicKeyPem(loxJson.decodeFromString<String>(keyMsg.value))
     }
 
     override suspend fun callRawForData(command: String): ByteArray {
@@ -104,6 +231,8 @@ class KtorWebsocketLoxoneClient internal constructor(
         }
         logger.debug { "Closing session" }
         session?.close(CloseReason(NORMAL, "LoxoneKotlin finished"))
+        sessionKey = null
+        publicKey = null
         scope.cancel("Closing the connection")
     }
 
@@ -216,16 +345,47 @@ class KtorWebsocketLoxoneClient internal constructor(
         }
     }
 
+    // Used solely for the keepalive command, which is never encrypted.
     private suspend fun ClientWebSocketSession.send(command: Command<*>) {
-        // TODO is url encoding of segments needed here?
         val joinedCmd = command.pathSegments.joinToString(separator = "/")
         logger.trace { "Sending command: $joinedCmd" }
         send(joinedCmd)
     }
 
+    /** AES session key/iv negotiated during key exchange, with per-command rotating salt. */
+    private class SessionKey(val aesKey: ByteArray, val iv: ByteArray) {
+        private var prevSalt: String? = null
+
+        /**
+         * Computes the salt prefix for the next command without committing the rotation: the first
+         * command uses `salt/{salt}`, subsequent ones `nextSalt/{prevSalt}/{nextSalt}` (anti-replay).
+         * Returns the prefix paired with the new salt; pass that salt to [commitSalt] only after the
+         * command round-trips successfully, so a failed send/receive doesn't desync the salt sequence.
+         */
+        fun nextSaltPart(): Pair<String, String> {
+            val next = LoxoneCrypto.generateSalt()
+            val part = prevSalt?.let { "nextSalt/$it/$next" } ?: "salt/$next"
+            return part to next
+        }
+
+        fun commitSalt(salt: String) {
+            prevSalt = salt
+        }
+    }
+
+    private class WrappedCommand(
+        val wire: String,
+        val responseEncrypted: Boolean,
+        val saltToCommit: String? = null
+    )
+
     companion object {
         private const val WS_PATH = "/ws/rfc6455"
         private const val DEFAULT_EVENT_BUFFER_SIZE = 100
+        private const val GET_PUBLIC_KEY_PATH = "/jdev/sys/getPublicKey"
+        private const val KEY_EXCHANGE_PREFIX = "jdev/sys/keyexchange/"
+        private const val ENC_PREFIX = "jdev/sys/enc/"
+        private const val FENC_PREFIX = "jdev/sys/fenc/"
         private val RCV_TXT_MSG_TIMEOUT = 10.seconds
         private val KEEP_ALIVE_INTERVAL = 4.minutes
         private val KEEP_ALIVE_RESPONSE_TIMEOUT = 30.seconds

--- a/src/commonMain/kotlin/message/SimpleLoxoneMsgCommand.kt
+++ b/src/commonMain/kotlin/message/SimpleLoxoneMsgCommand.kt
@@ -8,7 +8,8 @@ data class SimpleLoxoneMsgCommand<out VAL : LoxoneMsgVal> @JvmOverloads construc
     override val pathSegments: List<String>,
     override val valueType: KClass<out VAL>,
     override val authenticated: Boolean = true,
-    override val expectedCode: String = LoxoneMsg.CODE_OK
+    override val expectedCode: String = LoxoneMsg.CODE_OK,
+    override val encrypted: Boolean = false
 ) : LoxoneMsgCommand<VAL>
 
 internal inline fun <reified VAL : LoxoneMsgVal> cfgCommand(path: String): LoxoneMsgCommand<VAL> =
@@ -17,6 +18,7 @@ internal inline fun <reified VAL : LoxoneMsgVal> cfgCommand(path: String): Loxon
 internal inline fun <reified VAL : LoxoneMsgVal> sysCommand(
     vararg paths: String,
     authenticated: Boolean = true,
-    expectedCode: String = LoxoneMsg.CODE_OK
+    expectedCode: String = LoxoneMsg.CODE_OK,
+    encrypted: Boolean = false
 ): LoxoneMsgCommand<VAL> =
-    SimpleLoxoneMsgCommand(listOf("jdev", "sys") + paths, VAL::class, authenticated, expectedCode)
+    SimpleLoxoneMsgCommand(listOf("jdev", "sys") + paths, VAL::class, authenticated, expectedCode, encrypted)

--- a/src/commonTest/kotlin/LoxoneCommandsTest.kt
+++ b/src/commonTest/kotlin/LoxoneCommandsTest.kt
@@ -9,6 +9,11 @@ import io.kotest.matchers.shouldBe
 
 class LoxoneCommandsTest : ShouldSpec({
 
+    should("default commands to not encrypted") {
+        // KEEP_ALIVE does not override Command.encrypted, exercising the interface default
+        LoxoneCommands.KEEP_ALIVE.encrypted shouldBe false
+    }
+
     should("create kill token command") {
         LoxoneCommands.Tokens.kill("hash", "user").asClue {
             it.pathSegments shouldBe listOf("jdev", "sys", "killtoken", "hash", "user")
@@ -32,6 +37,7 @@ class LoxoneCommandsTest : ShouldSpec({
             it.valueType shouldBe Token::class
             it.authenticated shouldBe false
             it.expectedCode shouldBe "200"
+            it.encrypted shouldBe true
         }
     }
 
@@ -41,6 +47,7 @@ class LoxoneCommandsTest : ShouldSpec({
             it.valueType shouldBe Token::class
             it.authenticated shouldBe false
             it.expectedCode shouldBe "200"
+            it.encrypted shouldBe true
         }
     }
 })

--- a/src/commonTest/kotlin/LoxoneCryptoAesTest.kt
+++ b/src/commonTest/kotlin/LoxoneCryptoAesTest.kt
@@ -1,0 +1,60 @@
+package cz.smarteon.loxkt
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+@OptIn(ExperimentalEncodingApi::class)
+class LoxoneCryptoAesTest : ShouldSpec({
+
+    // 32-byte key / 16-byte IV (deterministic test vectors)
+    val key = ByteArray(32) { it.toByte() }
+    val iv = ByteArray(16) { (it + 1).toByte() }
+
+    context("AES-256-CBC encryption") {
+        should("roundtrip block-aligned plaintext") {
+            val plaintext = "0123456789ABCDEF" // exactly 16 bytes
+            LoxoneCrypto.aesDecrypt(LoxoneCrypto.aesEncrypt(plaintext, key, iv), key, iv) shouldBe plaintext
+        }
+
+        should("roundtrip non-block-aligned plaintext (ZeroBytePadding)") {
+            val plaintext = "salt/AB12/jdev/sps/io/AI1/on"
+            LoxoneCrypto.aesDecrypt(LoxoneCrypto.aesEncrypt(plaintext, key, iv), key, iv) shouldBe plaintext
+        }
+
+        should("produce Base64 output that differs from the plaintext") {
+            val plaintext = "salt/AB12/jdev/sps/io/AI1/on"
+            val encrypted = LoxoneCrypto.aesEncrypt(plaintext, key, iv)
+            encrypted.shouldNotBeEmpty()
+            encrypted shouldNotBe plaintext
+            // ciphertext is padded to the 16-byte block size
+            (Base64.decode(encrypted).size % 16) shouldBe 0
+        }
+
+        should("be deterministic for a fixed key and iv") {
+            val plaintext = "salt/AB12/jdev/sps/io/AI1/on"
+            LoxoneCrypto.aesEncrypt(plaintext, key, iv) shouldBe LoxoneCrypto.aesEncrypt(plaintext, key, iv)
+        }
+    }
+
+    context("key material generation") {
+        should("generate a 32-byte AES key") {
+            LoxoneCrypto.generateAesKey().size shouldBe 32
+        }
+
+        should("generate a 16-byte IV") {
+            LoxoneCrypto.generateAesIv().size shouldBe 16
+        }
+
+        should("generate random keys") {
+            LoxoneCrypto.generateAesKey() shouldNotBe LoxoneCrypto.generateAesKey()
+        }
+
+        should("generate a non-empty hex salt") {
+            LoxoneCrypto.generateSalt().shouldNotBeEmpty()
+        }
+    }
+})

--- a/src/jsMain/kotlin/LoxoneCrypto.js.kt
+++ b/src/jsMain/kotlin/LoxoneCrypto.js.kt
@@ -15,3 +15,37 @@ internal actual fun rsaEncryptBytes(data: ByteArray, publicKeyPem: String): Byte
     if (base64 == false) throw LoxoneException("RSA encryption failed — check key format and data size")
     return Base64.decode(base64 as String)
 }
+
+private val cryptoJs: dynamic get() = js("require('crypto-js')")
+
+private fun aesConfig(iv: ByteArray): dynamic {
+    val cfg = js("({})")
+    cfg.iv = cryptoJs.enc.Hex.parse(iv.toHex())
+    cfg.mode = cryptoJs.mode.CBC
+    cfg.padding = cryptoJs.pad.NoPadding
+    return cfg
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+internal actual fun aesEncryptBytes(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray {
+    val keyWa = cryptoJs.enc.Hex.parse(key.toHex())
+    val dataWa = cryptoJs.enc.Hex.parse(data.toHex())
+    val encrypted: dynamic = cryptoJs.AES.encrypt(dataWa, keyWa, aesConfig(iv))
+    return (encrypted.ciphertext.toString(cryptoJs.enc.Hex) as String).hexToByteArray()
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+internal actual fun aesDecryptBytes(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray {
+    val keyWa = cryptoJs.enc.Hex.parse(key.toHex())
+    val cipherParams = cryptoJs.lib.CipherParams.create(js("({})"))
+    cipherParams.ciphertext = cryptoJs.enc.Hex.parse(data.toHex())
+    val decrypted: dynamic = cryptoJs.AES.decrypt(cipherParams, keyWa, aesConfig(iv))
+    return (decrypted.toString(cryptoJs.enc.Hex) as String).hexToByteArray()
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+internal actual fun secureRandomBytes(size: Int): ByteArray =
+    (cryptoJs.lib.WordArray.random(size).toString(cryptoJs.enc.Hex) as String).hexToByteArray()
+
+@OptIn(ExperimentalStdlibApi::class)
+private fun ByteArray.toHex(): String = toHexString()

--- a/src/jvmTest/kotlin/LoxoneCryptoAesJvmTest.kt
+++ b/src/jvmTest/kotlin/LoxoneCryptoAesJvmTest.kt
@@ -1,0 +1,45 @@
+package cz.smarteon.loxkt
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Validates [LoxoneCrypto]'s AES against the JDK as an independent oracle, ensuring the multiplatform
+ * implementation produces standard AES-256-CBC output with Loxone's ZeroBytePadding.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class LoxoneCryptoAesJvmTest : ShouldSpec({
+
+    val key = ByteArray(32) { it.toByte() }
+    val iv = ByteArray(16) { (it + 1).toByte() }
+
+    fun jdkDecryptNoPadding(base64: String): ByteArray =
+        Cipher.getInstance("AES/CBC/NoPadding").run {
+            init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+            doFinal(Base64.decode(base64))
+        }
+
+    context("AES interop with the JDK") {
+        should("produce ciphertext the JDK decrypts to the zero-padded plaintext") {
+            val plaintext = "salt/AB12/jdev/sps/io/AI1/on"
+            val decrypted = jdkDecryptNoPadding(LoxoneCrypto.aesEncrypt(plaintext, key, iv))
+            decrypted.decodeToString().trimEnd('\u0000') shouldBe plaintext
+            // ZeroBytePadding pads to the block boundary
+            (decrypted.size % 16) shouldBe 0
+        }
+
+        should("decrypt ciphertext produced by the JDK") {
+            val plaintext = "0123456789ABCDEF0123456789ABCDEF" // 32 bytes, block aligned
+            val ciphertext = Cipher.getInstance("AES/CBC/NoPadding").run {
+                init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+                Base64.encode(doFinal(plaintext.encodeToByteArray()))
+            }
+            LoxoneCrypto.aesDecrypt(ciphertext, key, iv) shouldBe plaintext
+        }
+    }
+})

--- a/src/jvmTest/kotlin/LoxoneCryptoRsaTest.kt
+++ b/src/jvmTest/kotlin/LoxoneCryptoRsaTest.kt
@@ -41,4 +41,20 @@ class LoxoneCryptoRsaTest : ShouldSpec({
             RsaTestFixtures.decryptWithPrivateKey(encrypted) shouldBe sessionKey
         }
     }
+
+    context("public key normalization") {
+        // The Miniserver returns the key wrapped in CERTIFICATE markers on a single line.
+        val base64 = RsaTestFixtures.TEST_PUBLIC_KEY_PEM
+            .replace(Regex("-+(?:BEGIN|END) PUBLIC KEY-+"), "")
+            .replace(Regex("\\s"), "")
+        val certWrapped = "-----BEGIN CERTIFICATE-----$base64-----END CERTIFICATE-----"
+
+        should("convert a certificate-wrapped key to a usable PUBLIC KEY PEM") {
+            val normalized = LoxoneCrypto.normalizePublicKeyPem(certWrapped)
+            normalized shouldBe RsaTestFixtures.TEST_PUBLIC_KEY_PEM
+            // and it actually works for RSA encryption (decoder accepts the re-wrapped PEM)
+            val encrypted = LoxoneCrypto.rsaEncrypt("data", normalized)
+            RsaTestFixtures.decryptWithPrivateKey(encrypted) shouldBe "data"
+        }
+    }
 })

--- a/src/jvmTest/kotlin/ktor/CommandEncryptionIT.kt
+++ b/src/jvmTest/kotlin/ktor/CommandEncryptionIT.kt
@@ -1,0 +1,230 @@
+package cz.smarteon.loxkt.ktor
+
+import cz.smarteon.loxkt.CommandEncryption
+import cz.smarteon.loxkt.LoxoneException
+import cz.smarteon.loxkt.RsaTestFixtures
+import cz.smarteon.loxkt.message.EmptyLoxoneMsgVal
+import cz.smarteon.loxkt.message.SimpleLoxoneMsgCommand
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import java.net.URLDecoder
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * End-to-end command encryption test: a simulated Miniserver performs the RSA key exchange and
+ * AES-decrypts the wrapped commands, asserting the inner command, salt rotation, and fenc responses.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CommandEncryptionIT : StringSpec({
+
+    fun publicKeyResponse(): String {
+        // Mimic the Miniserver: the SubjectPublicKeyInfo base64 is wrapped in CERTIFICATE markers
+        // and returned as a plain string value (single line, no PEM line breaks).
+        val base64 = RsaTestFixtures.TEST_PUBLIC_KEY_PEM
+            .replace(Regex("-+(?:BEGIN|END) PUBLIC KEY-+"), "")
+            .replace(Regex("\\s"), "")
+        val certWrapped = "-----BEGIN CERTIFICATE-----$base64-----END CERTIFICATE-----"
+        return """{"LL":{"control":"dev/sys/getPublicKey","value":"$certWrapped","code":"200"}}"""
+    }
+
+    "REQUEST mode performs key exchange, wraps commands as enc, and rotates the salt" {
+        val miniserver = MiniserverCryptoSimulator()
+        val decryptedCommands = mutableListOf<String>()
+
+        val ctx = startTestWebSocketServer(
+            httpPublicKeyJson = publicKeyResponse(),
+            fallback = { payload ->
+                when {
+                    payload.startsWith("jdev/sys/keyexchange/") -> {
+                        miniserver.acceptKeyExchange(payload.substringAfter("jdev/sys/keyexchange/"))
+                        sendLoxoneResponse("""{"LL":{"control":"dev/sys/keyexchange","value":"","code":"200"}}""")
+                    }
+                    payload.startsWith("jdev/sys/enc/") -> {
+                        decryptedCommands += miniserver.decryptCommand(payload.substringAfter("jdev/sys/enc/"))
+                        sendLoxoneResponse("""{"LL":{"control":"enc","value":"ok","code":"200"}}""")
+                    }
+                }
+            }
+        )
+        val client = KtorWebsocketLoxoneClient(
+            ctx.testedClient,
+            commandEncryption = CommandEncryption.REQUEST,
+            dispatcher = UnconfinedTestDispatcher()
+        )
+
+        client.callRaw("jdev/sps/io/AI1/on")
+        client.callRaw("jdev/sps/io/AI2/off")
+        client.callRaw("jdev/sps/io/AI3/on")
+
+        // getPublicKey is fetched over HTTP, so the first websocket frame is the key exchange
+        ctx.received.receive() shouldStartWith "jdev/sys/keyexchange/"
+        repeat(3) { ctx.received.receive() shouldStartWith "jdev/sys/enc/" }
+
+        // first command carries the initial salt; each subsequent command rotates, using the
+        // previous command's nextSalt as its prevSalt (proves the salt sequence advances correctly)
+        decryptedCommands[0] shouldBe "salt/${miniserver.salts[0]}/jdev/sps/io/AI1/on"
+        decryptedCommands[1] shouldBe
+            "nextSalt/${miniserver.salts[0]}/${miniserver.salts[1]}/jdev/sps/io/AI2/off"
+        decryptedCommands[2] shouldBe
+            "nextSalt/${miniserver.salts[1]}/${miniserver.salts[2]}/jdev/sps/io/AI3/on"
+
+        client.close()
+    }
+
+    "REQUEST_RESPONSE mode decrypts the fenc response" {
+        val miniserver = MiniserverCryptoSimulator()
+
+        val ctx = startTestWebSocketServer(
+            httpPublicKeyJson = publicKeyResponse(),
+            fallback = { payload ->
+                when {
+                    payload.startsWith("jdev/sys/keyexchange/") -> {
+                        miniserver.acceptKeyExchange(payload.substringAfter("jdev/sys/keyexchange/"))
+                        sendLoxoneResponse("""{"LL":{"control":"dev/sys/keyexchange","value":"","code":"200"}}""")
+                    }
+                    payload.startsWith("jdev/sys/fenc/") -> {
+                        miniserver.decryptCommand(payload.substringAfter("jdev/sys/fenc/"))
+                        val plainJson = """{"LL":{"control":"fenc","value":"secret","code":"200"}}"""
+                        sendLoxoneResponse(miniserver.encryptResponse(plainJson))
+                    }
+                }
+            }
+        )
+        val client = KtorWebsocketLoxoneClient(
+            ctx.testedClient,
+            commandEncryption = CommandEncryption.REQUEST_RESPONSE,
+            dispatcher = UnconfinedTestDispatcher()
+        )
+
+        client.callRaw("jdev/sps/io/AI1/state") shouldBe
+            """{"LL":{"control":"fenc","value":"secret","code":"200"}}"""
+
+        client.close()
+    }
+
+    "NONE mode still encrypts commands flagged encrypted while leaving normal commands plain" {
+        val miniserver = MiniserverCryptoSimulator()
+        val decryptedCommands = mutableListOf<String>()
+
+        val ctx = startTestWebSocketServer(
+            httpPublicKeyJson = publicKeyResponse(),
+            fallback = { payload ->
+                when {
+                    payload.startsWith("jdev/sys/keyexchange/") -> {
+                        miniserver.acceptKeyExchange(payload.substringAfter("jdev/sys/keyexchange/"))
+                        sendLoxoneResponse("""{"LL":{"control":"dev/sys/keyexchange","value":"","code":"200"}}""")
+                    }
+                    payload.startsWith("jdev/sys/enc/") -> {
+                        decryptedCommands += miniserver.decryptCommand(payload.substringAfter("jdev/sys/enc/"))
+                        sendLoxoneResponse("""{"LL":{"control":"enc","value":"ok","code":"200"}}""")
+                    }
+                    else -> sendLoxoneResponse("""{"LL":{"control":"$payload","value":"ok","code":"200"}}""")
+                }
+            }
+        )
+        // NONE mode (default) - a command flagged encrypted must still be encrypted (e.g. token commands)
+        val client = KtorWebsocketLoxoneClient(ctx.testedClient, dispatcher = UnconfinedTestDispatcher())
+
+        val encryptedCmd = SimpleLoxoneMsgCommand(
+            listOf("jdev", "sys", "gettoken", "HASH"),
+            EmptyLoxoneMsgVal::class,
+            authenticated = false,
+            encrypted = true
+        )
+        client.call(encryptedCmd)
+        client.callRaw("jdev/cfg/api")
+
+        // the encrypted command triggers key exchange even in NONE mode, and goes out as enc
+        ctx.received.receive() shouldStartWith "jdev/sys/keyexchange/"
+        ctx.received.receive() shouldStartWith "jdev/sys/enc/"
+        // the normal command is sent verbatim (not encrypted)
+        ctx.received.receive() shouldBe "jdev/cfg/api"
+        decryptedCommands[0] shouldBe "salt/${miniserver.salts[0]}/jdev/sys/gettoken/HASH"
+
+        client.close()
+    }
+
+    "key exchange failure surfaces as LoxoneException" {
+        val ctx = startTestWebSocketServer(
+            httpPublicKeyJson = publicKeyResponse(),
+            fallback = { payload ->
+                if (payload.startsWith("jdev/sys/keyexchange/")) {
+                    sendLoxoneResponse("""{"LL":{"control":"keyexchange","value":"","code":"401"}}""")
+                }
+            }
+        )
+        val client = KtorWebsocketLoxoneClient(
+            ctx.testedClient,
+            commandEncryption = CommandEncryption.REQUEST,
+            dispatcher = UnconfinedTestDispatcher()
+        )
+        shouldThrow<LoxoneException> { client.callRaw("jdev/cfg/api") }
+        client.close()
+    }
+
+    "public key fetch failure surfaces as LoxoneException" {
+        val ctx = startTestWebSocketServer(
+            httpPublicKeyJson = """{"LL":{"control":"getPublicKey","value":"","code":"500"}}""",
+            fallback = { }
+        )
+        val client = KtorWebsocketLoxoneClient(
+            ctx.testedClient,
+            commandEncryption = CommandEncryption.REQUEST,
+            dispatcher = UnconfinedTestDispatcher()
+        )
+        shouldThrow<LoxoneException> { client.callRaw("jdev/cfg/api") }
+        client.close()
+    }
+})
+
+/** Simulates the Miniserver side of command encryption using the RSA test fixtures and the JDK AES. */
+private class MiniserverCryptoSimulator {
+    // Single volatile holder so the key + iv are published together (safe publication across the
+    // server's frame-handling coroutine, which may hop threads between suspensions).
+    @Volatile private var keyIv: Pair<ByteArray, ByteArray>? = null
+    val salts = mutableListOf<String>()
+
+    /** Recovers the AES key + iv from the RSA-encrypted session key (raw Base64, not url-encoded). */
+    fun acceptKeyExchange(sessionKeyBase64: String) {
+        val sessionKey = RsaTestFixtures.decryptWithPrivateKey(sessionKeyBase64)
+        val (keyHex, ivHex) = sessionKey.split(":")
+        keyIv = keyHex.hexToBytes() to ivHex.hexToBytes()
+    }
+
+    /** Decrypts an url-encoded, Base64 AES cipher and records the salt, returning the inner command. */
+    fun decryptCommand(encodedCipher: String): String {
+        val plain = aes(Cipher.DECRYPT_MODE, Base64.getDecoder().decode(urlDecode(encodedCipher)))
+            .decodeToString().trimEnd('\u0000')
+        // plaintext is "salt/{salt}/{cmd}" or "nextSalt/{prevSalt}/{nextSalt}/{cmd}"
+        val parts = plain.split("/")
+        if (parts[0] == "salt") salts += parts[1] else salts += parts[2]
+        return plain
+    }
+
+    /** AES-encrypts the response JSON (ZeroBytePadding) and Base64 encodes it for the fenc channel. */
+    fun encryptResponse(json: String): String {
+        val bytes = json.encodeToByteArray()
+        val padded = bytes.copyOf(bytes.size + (16 - bytes.size % 16) % 16)
+        return Base64.getEncoder().encodeToString(aes(Cipher.ENCRYPT_MODE, padded))
+    }
+
+    private fun aes(mode: Int, data: ByteArray): ByteArray {
+        val (key, iv) = checkNotNull(keyIv) { "key exchange not completed before command" }
+        return Cipher.getInstance("AES/CBC/NoPadding").run {
+            init(mode, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+            doFinal(data)
+        }
+    }
+
+    private fun urlDecode(value: String): String = URLDecoder.decode(value, "UTF-8")
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun String.hexToBytes(): ByteArray = hexToByteArray()
+}

--- a/src/jvmTest/kotlin/ktor/WebSocketTestServer.kt
+++ b/src/jvmTest/kotlin/ktor/WebSocketTestServer.kt
@@ -5,6 +5,7 @@ import cz.smarteon.loxkt.message.MessageHeader
 import cz.smarteon.loxkt.message.MessageKind.TEXT
 import io.ktor.client.*
 import io.ktor.server.application.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.server.websocket.*
@@ -21,7 +22,9 @@ data class WebSocketTestContext(val testedClient: HttpClient, val received: Chan
  * Each handler receives the session as receiver and the matched command string.
  */
 suspend fun startTestWebSocketServer(
-    vararg handlers: Pair<String, suspend WebSocketServerSession.(String) -> Unit>
+    vararg handlers: Pair<String, suspend WebSocketServerSession.(String) -> Unit>,
+    fallback: (suspend WebSocketServerSession.(String) -> Unit)? = null,
+    httpPublicKeyJson: String? = null
 ): WebSocketTestContext {
     val handlerMap = handlers.toMap()
     lateinit var ctx: WebSocketTestContext
@@ -31,6 +34,10 @@ suspend fun startTestWebSocketServer(
         val received = Channel<String>(Channel.BUFFERED)
 
         routing {
+            // The Miniserver serves getPublicKey over HTTP only (not the websocket channel).
+            if (httpPublicKeyJson != null) {
+                get("/jdev/sys/getPublicKey") { call.respondText(httpPublicKeyJson) }
+            }
             webSocketRaw(path = "/ws/rfc6455") {
                 incoming.consumeEach { frame ->
                     if (frame is Frame.Text) {
@@ -38,7 +45,7 @@ suspend fun startTestWebSocketServer(
                         received.send(payload)
                         when (payload) {
                             "keepalive" -> send(Frame.Binary(true, writeHeader(MessageHeader.KEEP_ALIVE)))
-                            else -> handlerMap[payload]?.invoke(this, payload)
+                            else -> (handlerMap[payload] ?: fallback)?.invoke(this, payload)
                         }
                     }
                 }

--- a/src/jvmTest/kotlin/ktor/WebsocketLoxoneClientIT.kt
+++ b/src/jvmTest/kotlin/ktor/WebsocketLoxoneClientIT.kt
@@ -1,5 +1,6 @@
 package cz.smarteon.loxkt.ktor
 
+import cz.smarteon.loxkt.LoxoneEndpoint
 import cz.smarteon.loxkt.message.ApiInfo
 import cz.smarteon.loxkt.message.TestingLoxValues.API_INFO_MSG_VAL
 import cz.smarteon.loxkt.message.TestingMessages.okMsg
@@ -32,6 +33,12 @@ class WebsocketLoxoneClientIT : StringSpec({
         bgDispatcher.scheduler.advanceTimeBy(245.seconds)
         ctx.received.receive() shouldBe "keepalive"
 
+        client.close()
+    }
+
+    "can be constructed via the public endpoint constructor and closed without connecting" {
+        // exercises the public constructor (builds its own HttpClient); no session is opened
+        val client = KtorWebsocketLoxoneClient(LoxoneEndpoint.local("127.0.0.1"))
         client.close()
     }
 })

--- a/src/nativeJvmMain/kotlin/LoxoneCrypto.nativeJvm.kt
+++ b/src/nativeJvmMain/kotlin/LoxoneCrypto.nativeJvm.kt
@@ -2,6 +2,7 @@ package cz.smarteon.loxkt
 
 import dev.whyoleg.cryptography.CryptographyProvider
 import dev.whyoleg.cryptography.DelicateCryptographyApi
+import dev.whyoleg.cryptography.algorithms.AES
 import dev.whyoleg.cryptography.algorithms.RSA
 import dev.whyoleg.cryptography.algorithms.SHA256
 
@@ -13,3 +14,37 @@ internal actual fun rsaEncryptBytes(data: ByteArray, publicKeyPem: String): Byte
         .decodeFromByteArrayBlocking(RSA.PublicKey.Format.PEM.Generic, publicKeyPem.encodeToByteArray())
         .encryptor()
         .encryptBlocking(data)
+
+private fun aesCipher(key: ByteArray) =
+    CryptographyProvider.Default
+        .get(AES.CBC)
+        .keyDecoder()
+        .decodeFromByteArrayBlocking(AES.Key.Format.RAW, key)
+        .cipher(padding = false)
+
+@OptIn(DelicateCryptographyApi::class)
+internal actual fun aesEncryptBytes(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray =
+    aesCipher(key).encryptWithIvBlocking(iv, data)
+
+@OptIn(DelicateCryptographyApi::class)
+internal actual fun aesDecryptBytes(data: ByteArray, key: ByteArray, iv: ByteArray): ByteArray =
+    aesCipher(key).decryptWithIvBlocking(iv, data)
+
+// cryptography-kotlin 0.6.0 exposes no general CSPRNG, so we derive random bytes from freshly
+// generated AES-256 keys (the key generator is backed by the platform secure RNG).
+// java.security.SecureRandom is available on JVM, but a single nativeJvmMain source set
+// avoids duplicating aesEncryptBytes/aesDecryptBytes/rsaEncryptBytes across jvmMain/nativeMain.
+// The per-connection overhead is negligible: secureRandomBytes is only called once during session
+// key setup.
+internal actual fun secureRandomBytes(size: Int): ByteArray {
+    val generator = CryptographyProvider.Default.get(AES.CBC).keyGenerator(AES.Key.Size.B256)
+    val out = ByteArray(size)
+    var offset = 0
+    while (offset < size) {
+        val block = generator.generateKeyBlocking().encodeToByteArrayBlocking(AES.Key.Format.RAW)
+        val take = minOf(block.size, size - offset)
+        block.copyInto(out, offset, 0, take)
+        offset += take
+    }
+    return out
+}


### PR DESCRIPTION
Implements the command-encryption layer for the WebSocket protocol (closes #76), building on the RSA work from #75.

## What
- **AES-256-CBC** encrypt/decrypt with ZeroBytePadding + secure random key/IV/salt, multiplatform (JVM/Native via `cryptography-kotlin`, JS via `crypto-js`).
- **WebSocket key exchange**: fetch the Miniserver public key over HTTP, RSA-wrap the AES session key, exchange before authentication.
- **enc/fenc wrapping** with per-command salt rotation (committed only after a successful round-trip); `fenc` responses are AES-decrypted before parsing.
- **Token commands** (`getjwt`/`authwithtoken`) are always encrypted (the Miniserver rejects them in plaintext); opt-in `CommandEncryption` mode (`NONE`/`REQUEST`/`REQUEST_RESPONSE`) for everything else.

## Validation
Verified **end-to-end against a real Miniserver** (acceptance test). Real-hardware protocol details that unit tests couldn't surface:
1. The public key is **HTTP-only** — `getPublicKey` is rejected on the WS channel (400).
2. It's returned as a **certificate-wrapped `SubjectPublicKeyInfo`** string, not a `{"publicKey":…}` object — normalized to a `PUBLIC KEY` PEM.
3. Key exchange must run **before** authentication.
4. The keyexchange session key is **raw Base64** (only `enc`/`fenc` ciphers are URI-component-encoded).

## Tests
AES roundtrip (common + JVM-vs-JDK oracle), public-key normalization + RSA roundtrip, and an end-to-end `CommandEncryptionIT` (key exchange + enc with 3-command salt rotation, fenc decrypt, NONE-mode forced encryption, and `LoxoneException` error paths). `jvmTest` (193 tests) + `detekt` green. Reviewed over two self-review rounds.

## Known limitations (see `docs/protocol-gap-analysis.md`)
- HTTP command encryption (`?sk=`) not wired — WS only.
- `REQUEST_RESPONSE` unsafe with binary/large responses (images/files/`LoxAPP3.json`).
- No reconnect; PR #75's `PublicKey` message model is now dormant; JS `actual` untested (JS test task disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)