### PR TITLE
feat(js): publish @smarteon/loxone-client to npm

### DIFF
--- a/.github/workflows/loxone-client-release.yml
+++ b/.github/workflows/loxone-client-release.yml
@@ -18,6 +18,7 @@ jobs:
   release:
     permissions:
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,3 +60,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASS }}
         run: |
           ./gradlew publishToMavenCentral
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        working-directory: build/dist/js/productionLibrary
+        run: npm publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,27 @@ kotlin {
         useEsModules()
         binaries.library()
         generateTypeScriptDefinitions()
+
+        compilations.named("main").configure {
+            packageJson {
+                customField("name", "@smarteon/loxone-client")
+                customField("description", "TypeScript/JavaScript client for the Loxone™ home automation system")
+                customField("license", "BSD-3-Clause")
+                customField("repository", mapOf(
+                    "type" to "git",
+                    "url" to "git+https://github.com/Smarteon/loxone-client-kotlin.git"
+                ))
+                customField("homepage", "https://github.com/Smarteon/loxone-client-kotlin")
+                customField("keywords", listOf("loxone", "home-automation", "smarthome", "kotlin", "multiplatform", "typescript"))
+                customField("exports", mapOf(
+                    "." to mapOf(
+                        "import" to "./loxone-client-kotlin.mjs",
+                        "types" to "./loxone-client-kotlin.d.mts"
+                    )
+                ))
+                customField("publishConfig", mapOf("access" to "public"))
+            }
+        }
     }
     linuxArm64()
     linuxX64()


### PR DESCRIPTION
## Summary

- Configures the JS compilation's `package.json` with full npm metadata: scoped name `@smarteon/loxone-client`, description, license, repository, homepage, keywords, ESM `exports` map, and `publishConfig.access=public`
- Extends the release workflow with a Node.js 22 setup step and an `npm publish` step using **Trusted Publishing** (OIDC, no static token) — `id-token: write` permission added to the job

## Prerequisites before triggering a release

- [x] `@smarteon` npm org created
- [x] First publish done manually (bootstrap) — package exists at npmjs.com/package/@smarteon/loxone-client
- [x] Trusted Publisher configured on npmjs.com (owner: `Smarteon`, repo: `loxone-client-kotlin`, workflow: `loxone-client-release.yml`)

## Test plan

- [ ] Confirm `build/dist/js/productionLibrary/package.json` contains all metadata fields after `./gradlew jsBrowserProductionLibraryDistribution`
- [ ] Trigger release workflow after Trusted Publisher is configured and verify npm publish step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)