### PR TITLE
fix(ci): build JS distribution before npm publish

### DIFF
--- a/.github/workflows/loxone-client-release.yml
+++ b/.github/workflows/loxone-client-release.yml
@@ -68,5 +68,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
-        working-directory: build/dist/js/productionLibrary
-        run: npm publish
+        shell: bash
+        run: |
+          ./gradlew jsBrowserProductionLibraryDistribution
+          cd build/dist/js/productionLibrary
+          npm publish


### PR DESCRIPTION
## Summary

- `publishToMavenCentral` does not run `jsBrowserProductionLibraryDistribution`, so `build/dist/js/productionLibrary/` was missing when the npm publish step ran
- Fix: explicitly run `./gradlew jsBrowserProductionLibraryDistribution` in the npm publish step before `npm publish`

## Test plan

- [ ] Trigger the release workflow and verify the npm publish step completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)